### PR TITLE
Use round robin for service URLS

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -7,9 +7,7 @@ import (
 	"time"
 )
 
-// SelectServiceURL gets a eureka instance based on the connection's load
-// balancing scheme.
-// TODO: Make this not just pick a random one.
+// SelectServiceURL gets a eureka instance using a round robin algorithm
 func (e *EurekaConnection) SelectServiceURL() string {
 
 	if e.discoveryTtl == nil {

--- a/round_robin.go
+++ b/round_robin.go
@@ -32,7 +32,7 @@ func (r *roundrobinImpl) Next() string {
 
 func (r *roundrobinImpl) Matches(other []string) bool {
 
-	if (other == nil) != (r.urls == nil) {
+	if (other == nil) || (r.urls == nil) {
 		return false
 	}
 

--- a/round_robin.go
+++ b/round_robin.go
@@ -1,0 +1,50 @@
+package fargo
+
+import (
+	"sync"
+)
+
+type roundRobin interface {
+	Next() string
+	Matches([]string) bool
+}
+
+type roundrobinImpl struct {
+	urls []string
+	mu   *sync.Mutex
+	next int
+}
+
+func newRoundRobin(urls []string) roundRobin {
+	return &roundrobinImpl{
+		urls: urls,
+		mu:   new(sync.Mutex),
+	}
+}
+
+func (r *roundrobinImpl) Next() string {
+	r.mu.Lock()
+	sc := r.urls[r.next]
+	r.next = (r.next + 1) % len(r.urls)
+	r.mu.Unlock()
+	return sc
+}
+
+func (r *roundrobinImpl) Matches(other []string) bool {
+
+	if (other == nil) != (r.urls == nil) {
+		return false
+	}
+
+	if len(other) != len(r.urls) {
+		return false
+	}
+
+	for i := range r.urls {
+		if r.urls[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/round_robin_test.go
+++ b/round_robin_test.go
@@ -1,0 +1,40 @@
+package fargo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRoundRobin(t *testing.T) {
+	tests := []struct {
+		urls []string
+		want []string
+	}{
+		{
+			urls: []string{
+				"192.168.33.10",
+				"192.168.33.11",
+				"192.168.33.12",
+			},
+			want: []string{
+				"192.168.33.10",
+				"192.168.33.11",
+				"192.168.33.12",
+				"192.168.33.10",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		rr := newRoundRobin(test.urls)
+
+		gots := make([]string, 0, len(test.want))
+		for j := 0; j < len(test.want); j++ {
+			gots = append(gots, rr.Next())
+		}
+
+		if got, want := gots, test.want; !reflect.DeepEqual(got, want) {
+			t.Errorf("tests[%d] - RoundRobin is wrong. want: %v, got: %v", i, want, got)
+		}
+	}
+}

--- a/struct.go
+++ b/struct.go
@@ -26,6 +26,7 @@ type EurekaConnection struct {
 	DNSDiscovery   bool
 	DiscoveryZone  string
 	discoveryTtl   chan struct{}
+	roundRobin     roundRobin
 	UseJson        bool
 }
 


### PR DESCRIPTION
Fork of the base fargo client, with a round robin instead of a random choice for service urls.