### PR TITLE
Add support for client region

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	AWS    aws
 	Eureka eureka
+	Client client
 }
 
 type aws struct {
@@ -40,6 +41,10 @@ type eureka struct {
 	PreferSameZone        bool     // default false
 	RegisterWithEureka    bool     // default false
 	Retries               int      // default 3
+}
+
+type client struct {
+	Region string
 }
 
 // ReadConfig from a file location. Minimal error handling. Just bails and passes up

--- a/connection.go
+++ b/connection.go
@@ -32,7 +32,7 @@ func (e *EurekaConnection) shouldUseDNSDiscovery() bool {
 }
 
 func (e *EurekaConnection) refreshServiceUrls() error {
-	serversUrls, ttl, err := discoverDNS(e.DiscoveryZone, e.ServicePort, e.ServerURLBase)
+	serversUrls, ttl, err := discoverDNS(e.DiscoveryZone, e.ServicePort, e.ServerURLBase, e.ClientRegion)
 	if err != nil {
 		return err
 	}
@@ -70,6 +70,7 @@ func NewConnFromConfig(conf Config) (c EurekaConnection) {
 	if len(c.ServiceUrls) == 0 && len(conf.Eureka.ServerDNSName) > 0 {
 		c.ServiceUrls = []string{conf.Eureka.ServerDNSName}
 	}
+	c.ClientRegion = conf.Client.Region
 	c.Timeout = time.Duration(conf.Eureka.ConnectTimeoutSeconds) * time.Second
 	c.PollInterval = time.Duration(conf.Eureka.PollIntervalSeconds) * time.Second
 	c.PreferSameZone = conf.Eureka.PreferSameZone

--- a/dns_discover.go
+++ b/dns_discover.go
@@ -4,18 +4,24 @@ package fargo
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/cenkalti/backoff"
 	"github.com/franela/goreq"
 	"github.com/miekg/dns"
-	"time"
 )
 
 const azURL = "http://169.254.169.254/latest/meta-data/placement/availability-zone"
 
 var ErrNotInAWS = fmt.Errorf("Not in AWS")
 
-func discoverDNS(domain string, port int, urlBase string) (servers []string, ttl time.Duration, err error) {
-	r, _ := region()
+func discoverDNS(domain string, port int, urlBase string, clientRegion string) (servers []string, ttl time.Duration, err error) {
+	var r = string
+	if clientRegion != "" {
+		r = clientRegion
+	} else {
+		r = region()
+	}
 
 	// all DNS queries must use the FQDN
 	domain = "txt." + r + "." + dns.Fqdn(domain)

--- a/dns_discover.go
+++ b/dns_discover.go
@@ -20,7 +20,8 @@ func discoverDNS(domain string, port int, urlBase string, clientRegion string) (
 	if clientRegion != "" {
 		r = clientRegion
 	} else {
-		r, _ := region()
+		regionResolvedAutomatically, _ := region()
+		r = regionResolvedAutomatically
 	}
 
 	// all DNS queries must use the FQDN

--- a/dns_discover.go
+++ b/dns_discover.go
@@ -16,11 +16,11 @@ const azURL = "http://169.254.169.254/latest/meta-data/placement/availability-zo
 var ErrNotInAWS = fmt.Errorf("Not in AWS")
 
 func discoverDNS(domain string, port int, urlBase string, clientRegion string) (servers []string, ttl time.Duration, err error) {
-	var r = string
+	var r string
 	if clientRegion != "" {
 		r = clientRegion
 	} else {
-		r = region()
+		r, _ := region()
 	}
 
 	// all DNS queries must use the FQDN

--- a/struct.go
+++ b/struct.go
@@ -25,6 +25,7 @@ type EurekaConnection struct {
 	Retries        int
 	DNSDiscovery   bool
 	DiscoveryZone  string
+	ClientRegion   string
 	discoveryTtl   chan struct{}
 	roundRobin     roundRobin
 	UseJson        bool


### PR DESCRIPTION
This is a change needed to support multi region deployment.

The way our eureka is configured, we have a single centralized eureka instance in our main region, from which we must fetch the correct discovery zone.

Otherwise, the could would try to find the DNS zone from the current aws region (which would not work)